### PR TITLE
Sanitize the sortBy param and directly interpolate it in the query

### DIFF
--- a/routes/auth/user/getUsers.ts
+++ b/routes/auth/user/getUsers.ts
@@ -3,17 +3,28 @@ import {
   event,
   extractPaginationParams,
   extractSortParams,
-} from "#src/utils";
+} from '#src/utils';
+
+const allowedSortFields = ['user_id', 'role', 'name', 'email'];
+const allowedSortDirections = ['ASC', 'DESC'];
 
 export const getUsers = async () => {
   const { limit, offset } = extractPaginationParams(event);
   const { sortBy, sort } = extractSortParams(event);
 
+  // PostgreSQL injection prevention since we need to directly interpolate the sortBy
+  const sanitizedSortBy = allowedSortFields.includes(sortBy)
+    ? sortBy
+    : 'user_id';
+  const sanitizedSort = allowedSortDirections.includes(sort.toUpperCase())
+    ? sort.toUpperCase()
+    : 'ASC';
+
   await db.connect();
   const rows = (
     await db.query({
-      text: `SELECT * FROM "users" ORDER BY $3 $4 LIMIT $1 OFFSET $2`,
-      values: [limit, offset, sortBy, sort],
+      text: `SELECT * FROM "users" ORDER BY ${sanitizedSortBy} ${sanitizedSort} LIMIT $1 OFFSET $2`,
+      values: [limit, offset],
     })
   ).rows;
   await db.clean();


### PR DESCRIPTION
Looks like PG doesn't support including actual column names as part of the query values. You need to manually interpolate them into the query, which means we need to sanitize the input.