### PR TITLE
Change: Return whole obj on create or update (will complete App #216)

### DIFF
--- a/routes/auth/guest/addGuest.ts
+++ b/routes/auth/guest/addGuest.ts
@@ -16,12 +16,12 @@ export const addGuest = async () => {
   const sanitizedDob = dob === '' ? null : dob;
 
   await db.connect();
-  const guest_id = (
+  const guest = (
     await db.query({
-      text: `INSERT INTO "guests" ("first_name", "last_name", "dob", "case_manager") VALUES ($1, $2, $3, $4) RETURNING "guest_id"`,
+      text: `INSERT INTO "guests" ("first_name", "last_name", "dob", "case_manager") VALUES ($1, $2, $3, $4) RETURNING *`,
       values: [first_name, last_name, sanitizedDob, case_manager],
     })
-  ).rows?.[0]?.guest_id;
+  ).rows?.[0];
   await db.clean();
-  return { guest_id };
+  return { guest, guest_id: guest.guest_id };
 };

--- a/routes/auth/guest/updateGuest.ts
+++ b/routes/auth/guest/updateGuest.ts
@@ -3,10 +3,10 @@ import { db, event } from '#src/utils'
 export const updateGuest = async () => {
     const { first_name, last_name, dob, case_manager, guest_id } = event.body;
     await db.connect();
-    await db.query({
-        text: `UPDATE "guests" SET "first_name"=$1, "last_name"=$2, "dob"=$3, "case_manager"=$4, "updated_at"=$5 WHERE "guest_id"=$6`,
+    const guest = (await db.query({
+        text: `UPDATE "guests" SET "first_name"=$1, "last_name"=$2, "dob"=$3, "case_manager"=$4, "updated_at"=$5 WHERE "guest_id"=$6 RETURNING *`,
         values: [first_name, last_name, dob, case_manager, new Date().toISOString(), guest_id],
-    });
+    })).rows?.[0];
     await db.clean();
-    return { success: true };
+    return { success: true, guest };
 }

--- a/routes/auth/notifications/addGuestNotification.ts
+++ b/routes/auth/notifications/addGuestNotification.ts
@@ -6,10 +6,10 @@ export const addGuestNotification = async () => {
         return { error: `Status must be one of the following: null, Archived, Active` }
     }
     await db.connect();
-    const notification_id = (await db.query({
-        text: `INSERT INTO "guest_notifications" ("guest_id", "message", "status") VALUES ($1, $2, $3) RETURNING "notification_id"`,
+    const notification = (await db.query({
+        text: `INSERT INTO "guest_notifications" ("guest_id", "message", "status") VALUES ($1, $2, $3) RETURNING *`,
         values: [guest_id, message, status],
-    })).rows?.[0]?.notification_id;
+    })).rows?.[0];
     await db.clean();
-    return { notification_id };
+    return { notification, notification_id: notification.notification_id };
 }

--- a/routes/auth/notifications/updateGuestNotification.ts
+++ b/routes/auth/notifications/updateGuestNotification.ts
@@ -3,10 +3,10 @@ import { db, event } from '#src/utils'
 export const updateGuestNotification = async () => {
     const { status, message, notification_id } = event.body;
     await db.connect();
-    await db.query({
-        text: `UPDATE "guest_notifications" SET "status"=$1, "message"=$2, "updated_at"=$3 WHERE "notification_id"=$4`,
+    const notification = (await db.query({
+        text: `UPDATE "guest_notifications" SET "status"=$1, "message"=$2, "updated_at"=$3 WHERE "notification_id"=$4 RETURNING *`,
         values: [status, message, new Date().toISOString(), notification_id],
-    });
+    })).rows?.[0];
     await db.clean();
-    return { success: true };
+    return { success: true, notification };
 }

--- a/routes/auth/service/addService.ts
+++ b/routes/auth/service/addService.ts
@@ -3,10 +3,10 @@ import { db, event } from '#src/utils'
 export const addService = async () => {
     const { name, quota } = event.body;
     await db.connect();
-    const service_id = (await db.query({
-        text: `INSERT INTO "services" ("name", "quota") VALUES ($1, $2) RETURNING "service_id"`,
+    const service = (await db.query({
+        text: `INSERT INTO "services" ("name", "quota") VALUES ($1, $2) RETURNING *`,
         values: [name, quota],
-    })).rows?.[0]?.service_id;
+    })).rows?.[0];
     await db.clean();
-    return { service_id };
+    return { service, service_id: service.service_id};
 }

--- a/routes/auth/service/updateService.ts
+++ b/routes/auth/service/updateService.ts
@@ -3,10 +3,10 @@ import { db, event } from '#src/utils';
 export const updateService = async () => {
   const { name, quota, queueable, service_id } = event.body;
   await db.connect();
-  await db.query({
-    text: `UPDATE "services" SET "name"=$1, "quota"=$2, "queueable"=$3,"updated_at"=$4 WHERE "service_id"=$5`,
+  const service = (await db.query({
+    text: `UPDATE "services" SET "name"=$1, "quota"=$2, "queueable"=$3,"updated_at"=$4 WHERE "service_id"=$5 RETURNING *`,
     values: [name, quota, queueable, new Date().toISOString(), service_id],
-  });
+  })).rows?.[0];
   await db.clean();
-  return { success: true };
+  return { success: true, service };
 };


### PR DESCRIPTION
This PR + API #30 completes App [#216](https://github.com/1111philo/apolis-app/issues/216).

This covers: 

/addGuest
/updateGuest
/updateGuestNotifications (/add was covered in a previous PR), 
/addService
/updateService (awaiting fix*)

*NOTE: Awaiting a fix for /updateService in localstack before removing draft status from this PR. Seems the localstack DB instance may not be in sync with the live staging instance, which is causing problems with /updateService.

NOTE: I have no plans to make the same change to /addVisit as I don't see where it would be helpful at the moment. I doubt we'll ever add a visit from a view that displays a list of visits.