### PR TITLE
Change: Query Users by ID instead of sub

### DIFF
--- a/routes/auth/user/getUser.ts
+++ b/routes/auth/user/getUser.ts
@@ -1,17 +1,17 @@
 import { db, event } from '#src/utils';
 
 export const getUser = async () => {
-  const sub = event.body?.sub;
+  const user_id = event.body?.user_id;
 
-  if (!sub) {
-    return { error: 'User sub is required' };
+  if (!user_id) {
+    return { error: 'User ID is required' };
   }
 
   await db.connect();
   const user = (
     await db.query({
-      text: `SELECT * FROM "users" WHERE "sub" = $1`,
-      values: [sub],
+      text: `SELECT * FROM "users" WHERE "user_id" = $1`,
+      values: [user_id],
     })
   ).rows?.[0];
   await db.clean();


### PR DESCRIPTION
Why?

We're having issues related to the sub -- when a user is updated, something unexpected happens in Cognito. The effect is that the sub returned from login is not that stored in the DB for the User.

This is a "quick" fix.